### PR TITLE
Update docx-machina/docx-annon rubyzip dependency

### DIFF
--- a/docx_anon.gemspec
+++ b/docx_anon.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
   spec.add_dependency "nokogiri", "< 2"
-  spec.add_dependency "rubyzip",  "< 2"
+  spec.add_dependency "rubyzip",  "~>2.3.0"
 
   spec.add_development_dependency "exiftool", "< 2"
   spec.add_development_dependency "bundler", ">= 1.16"

--- a/lib/docx_anon/version.rb
+++ b/lib/docx_anon/version.rb
@@ -1,3 +1,3 @@
 module DocxAnon
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end


### PR DESCRIPTION
### Description
A continuation of https://github.com/scholastica/docx-machina/pull/31.

Essentially we are bumping the version of rubyzip to avoid potential security issues